### PR TITLE
Feat: sortFn for Explorer to match original docs

### DIFF
--- a/functions.ts
+++ b/functions.ts
@@ -1,0 +1,40 @@
+import { Options } from "./quartz/components/ExplorerNode"
+
+// custom sort order for folders to match original docs
+export const sortFn: Options["sortFn"] = (a, b) => {
+    const nameOrderMap: Record<string, number> = {
+      "getting-started": 100,
+      "data-files": 200,
+      "building-and-editing": 300,
+        "world": 301,
+        "main-editing-windows": 302,
+        "landscape": 303,
+      "objects": 400,
+        "object-types": 401,
+        "reference-data": 402,
+      "actors": 500,
+        "character": 501,
+        "creature": 502,
+        "dialogue": 503,
+        "ai": 504,
+      "gameplay": 600,
+        "scripting": 601
+    }
+ 
+    let orderA = 700
+    let orderB = 700
+ 
+    if (a.file && a.file.slug) {
+      orderA = nameOrderMap[a.file.slug] || 700
+    } else if (a.name) {
+      orderA = nameOrderMap[a.name] || 700
+    }
+ 
+    if (b.file && b.file.slug) {
+      orderB = nameOrderMap[b.file.slug] || 700
+    } else if (b.name) {
+      orderB = nameOrderMap[b.name] || 700
+    }
+ 
+    return orderA - orderB
+}

--- a/quartz.layout.ts
+++ b/quartz.layout.ts
@@ -1,5 +1,6 @@
 import { PageLayout, SharedLayout } from "./quartz/cfg"
 import * as Component from "./quartz/components"
+import { sortFn } from "./functions"
 
 // components shared across all pages
 export const sharedPageComponents: SharedLayout = {
@@ -29,10 +30,16 @@ export const defaultContentPageLayout: PageLayout = {
     Component.MobileOnly(Component.Spacer()),
     Component.Search(),
     Component.Darkmode(),
-    Component.DesktopOnly(Component.Explorer({folderClickBehavior: "link"})),
+    Component.DesktopOnly(Component.Explorer({
+      folderClickBehavior: "link",
+      sortFn: sortFn,
+    })),
   ],
   right: [
-    Component.MobileOnly(Component.Explorer({folderClickBehavior: "link"})),
+    Component.MobileOnly(Component.Explorer({
+      folderClickBehavior: "link",
+      sortFn: sortFn,
+    })),
     Component.DesktopOnly(Component.Graph()),
     Component.DesktopOnly(Component.TableOfContents()),
     Component.Backlinks(),
@@ -47,10 +54,16 @@ export const defaultListPageLayout: PageLayout = {
     Component.MobileOnly(Component.Spacer()),
     Component.Search(),
     Component.Darkmode(),
-    Component.DesktopOnly(Component.Explorer({folderClickBehavior: "link"})),
+    Component.DesktopOnly(Component.Explorer({
+      folderClickBehavior: "link",
+      sortFn: sortFn,
+    })),
   ],
   right: [
-    Component.MobileOnly(Component.Explorer({folderClickBehavior: "link"})),
+    Component.MobileOnly(Component.Explorer({
+      folderClickBehavior: "link",
+      sortFn: sortFn,
+    })),
     Component.DesktopOnly(Component.Graph()),
     Component.DesktopOnly(Component.TableOfContents()),
     Component.Backlinks(),


### PR DESCRIPTION
Added a sortFn with [pre-defined order for the Explorer](https://quartz.jzhao.xyz/features/explorer#use-sort-with-pre-defined-sort-order) in new file `./function.ts`.

This allows the folders to follow the same order as the original WinHelp docs