### PR TITLE
Fix: Reduce line height for txt-s tables

### DIFF
--- a/quartz/styles/custom/callout-adjustments.scss
+++ b/quartz/styles/custom/callout-adjustments.scss
@@ -218,6 +218,12 @@
   font-size: 0.8rem;
 }
 
+.callout.callout:is([data-callout-metadata~=text-small],
+[data-callout-metadata~=txt-s]) > .callout-content > .table-container > table > * {
+  // override Quartz default table line-height 2rem
+  line-height: 1.6rem;
+}
+
 .callout:is([data-callout-metadata~=n-th],
 [data-callout-metadata~=no-table-header]) > .callout-content table {
   margin-bottom: 5px;


### PR DESCRIPTION
Reduce line-height of tables to 1.6rem if table is inside a callout with `|txt-s` adjustment.

Quartz's default line-height for tables is 2rem. If using the `|txt-s` callout adjustment to reduce font-size of callout content, tables inside the callout do not have their line-height reduced to the scale of the reduced text size, so lines appear abnormally far apart.